### PR TITLE
Legacy variables should be optional

### DIFF
--- a/tasks/get.yaml
+++ b/tasks/get.yaml
@@ -8,7 +8,9 @@
 # If no placement was found, try compatibility mode (legacy), query dynamoDB
 # TODO: remove later
 # (when everything is using the sandbox-api and all services have a Placement in DB)
-- when: sandbox_name is not defined
+- when:
+    - sandbox_name is not defined
+    - pool_manager_aws_access_key_id | default('', true) != ''
   include_tasks: legacy_get.yaml
 
 # If no sandbox associated, book a new one using the Sandbox API
@@ -19,7 +21,9 @@
 
 # Keep this in case sandbox_api_token is not defined
 # TODO: remove later
-- when: sandbox_name is not defined
+- when:
+    - sandbox_name is not defined
+    - pool_manager_aws_access_key_id | default('', true) != ''
   include_tasks: legacy_book.yaml
 
 - debug:

--- a/tasks/pre_checks.yaml
+++ b/tasks/pre_checks.yaml
@@ -37,24 +37,6 @@
     - msg: Variable env_type is not defined
       that: env_type is defined and env_type != ''
 
-    - msg: Variable pool_region is not defined
-      that: pool_region is defined and pool_region != ''
-
-    - msg: Variable pool_manager_aws_access_key_id is not defined
-      that:
-        - pool_manager_aws_access_key_id is defined
-        - pool_manager_aws_access_key_id != ''
-
-    - msg: Variable pool_manager_aws_secret_access_key is not defined
-      that:
-        - pool_manager_aws_secret_access_key is defined
-        - pool_manager_aws_secret_access_key != ''
-
-    - msg: Variable pool_manager_vault_password is not defined
-      that:
-        - pool_manager_vault_password is defined
-        - pool_manager_vault_password != ''
-
     - msg: email and student name can't be both undefined
       that: >-
         email is defined and email != ''

--- a/tasks/release.yaml
+++ b/tasks/release.yaml
@@ -7,5 +7,7 @@
 # If sandbox-api tasks didn't run or if placement was not found, it's safe to run legacy code to mark for cleanup any account matching uuid.
 # TODO: remove later
 # (when everything is using the sandbox-api and all services have a Placement in DB)
-- when: r_del.status | default(404) == 404
+- when:
+    - r_del.status | default(404) == 404
+    - pool_manager_aws_access_key_id | default('', true) != ''
   include_tasks: legacy_release.yaml


### PR DESCRIPTION
We now use the Sandbox API. Legacy variables used to interact with the DynamoDB directly should be optional.

This change, if applied, remove the error messages if the variables are not defined and make sure the tasks are included only when the legacy variables are defined.