### PR TITLE
Update condition for placements with no resource

### DIFF
--- a/tasks/sandbox_api_get.yaml
+++ b/tasks/sandbox_api_get.yaml
@@ -12,7 +12,9 @@
   until: r_get_placement is succeeded
 
 # Placement found
-- when: r_get_placement.status == 200
+- when: >-
+    r_get_placement.status == 200
+    and r_get_placement.json.resources | default([]) | length > 0
   block:
     - name: Set placement
       set_fact:


### PR DESCRIPTION
fixes

```
TASK [babylon_aws_sandbox : Save sandbox variables] ****************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'dict object' has no attribute 'resources'. 'dict object' has no attribute 'resources'\n\nThe error appears to be in '/opt/app-root/anarchy-runner/.ansible/requirements-e9d0abacbd6d79b2edaa4090d76b841d/roles/babylon_aws_sandbox/tasks/sandbox_api_get.yaml': line 21, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n    - name: Save sandbox variables\n      ^ here\n"}
```