### PR TITLE
Fix destroy when AWS Sandbox Placement is empty

### DIFF
--- a/tasks/get.yaml
+++ b/tasks/get.yaml
@@ -8,67 +8,25 @@
 # If no placement was found, try compatibility mode (legacy), query dynamoDB
 # TODO: remove later
 # (when everything is using the sandbox-api and all services have a Placement in DB)
-- when:
-    - sandbox_name is not defined
-    - pool_manager_aws_access_key_id | default('', true) != ''
+- when: >-
+    r_get_placement.status | default(0, true) != 200
+    and sandbox_name is not defined
+    and pool_manager_aws_access_key_id | default('', true) != ''
   include_tasks: legacy_get.yaml
 
 # If no sandbox associated, book a new one using the Sandbox API
+# Run book only if the action is 'provision'
 - when: >-
-    sandbox_name is not defined
+    anarchy_action_config_name == 'provision'
+    and r_get_placement.status | default(0, true) != 200
+    and sandbox_name is not defined
     and sandbox_api_login_token | default("") != ""
   include_tasks: sandbox_api_book.yaml
 
 # Keep this in case sandbox_api_token is not defined
 # TODO: remove later
 - when:
+    - anarchy_action_config_name == 'provision'
     - sandbox_name is not defined
     - pool_manager_aws_access_key_id | default('', true) != ''
   include_tasks: legacy_book.yaml
-
-- debug:
-    msg: >-
-      Sandbox {{ sandbox_name }} picked
-      uuid={{ uuid }}
-      guid={{ guid }}
-      env_type={{ env_type }}"
-
-- name: Save secret of aws_sandbox_secrets dictionary
-  set_fact:
-    aws_sandbox_secrets:
-      sandbox_aws_access_key_id: "{{ sandbox_aws_access_key_id }}"
-      sandbox_aws_secret_access_key: "{{ sandbox_aws_secret_access_key }}"
-      sandbox_hosted_zone_id: "{{ sandbox_hosted_zone_id }}"
-      sandbox_name: "{{ sandbox_name }}"
-      sandbox_account: "{{ sandbox_account }}"
-      sandbox_account_id: "{{ sandbox_account_id }}"
-      sandbox_zone: "{{ sandbox_zone }}"
-      # agnosticd
-      aws_access_key_id: "{{ sandbox_aws_access_key_id }}"
-      aws_secret_access_key: "{{ sandbox_aws_secret_access_key }}"
-      HostedZoneId: "{{ sandbox_hosted_zone_id }}"
-      subdomain_base_suffix: ".{{ sandbox_zone }}"
-
-- name: Inject secrets into dynamic_job_vars
-  set_fact:
-    dynamic_job_vars: >-
-      {{ vars.dynamic_job_vars
-      | default({})
-      | combine(aws_sandbox_secrets, recursive=True) }}
-
-- name: Set sandbox for {{ anarchy_subject_name }}
-  anarchy_subject_update:
-    skip_update_processing: true
-    metadata:
-      labels:
-        sandbox: "{{ sandbox_name }}"
-    spec:
-      vars:
-        job_vars:
-          sandbox_name: "{{ sandbox_name }}"
-          sandbox_account: "{{ sandbox_account }}"
-          sandbox_zone: "{{ sandbox_zone }}"
-          sandbox_hosted_zone_id: "{{ sandbox_hosted_zone_id }}"
-          # agnosticd
-          HostedZoneId: "{{ sandbox_hosted_zone_id }}"
-          subdomain_base_suffix: ".{{ sandbox_zone }}"

--- a/tasks/legacy_book.yaml
+++ b/tasks/legacy_book.yaml
@@ -182,3 +182,5 @@
           vars:
             vaulted_text: "{{ sandbox_aws_secret_access_key }}"
           include_tasks: unvault.yml
+
+        - include_tasks: set_aws_sandbox.yaml

--- a/tasks/legacy_get.yaml
+++ b/tasks/legacy_get.yaml
@@ -61,3 +61,5 @@
           vars:
             vaulted_text: "{{ query1.Items[0].aws_secret_access_key.S }}"
           include_tasks: unvault.yml
+
+        - include_tasks: set_aws_sandbox.yaml

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -33,6 +33,9 @@
         )
       include_tasks: release.yaml
 
+    # The following proceed with the deletion of the anarchy subject if the Placement
+    # is deleted, even if the tower job failed.
+    # TODO: add agnosticv __meta__ value to control this in case we require the tower job to succeed
     - name: Complete deletion anarchy subject on destroy failure
       when: >-
         'destroy-error' == current_state | default('') or

--- a/tasks/sandbox_api_book.yaml
+++ b/tasks/sandbox_api_book.yaml
@@ -60,3 +60,5 @@
       | selectattr('kind', 'equalto', 'aws_iam_key')
       | selectattr('name', 'equalto', 'admin-key')
       | first).get('aws_secret_access_key') }}
+
+- include_tasks: set_aws_sandbox.yaml

--- a/tasks/sandbox_api_get.yaml
+++ b/tasks/sandbox_api_get.yaml
@@ -38,3 +38,5 @@
           | selectattr('kind', 'equalto', 'aws_iam_key')
           | selectattr('name', 'equalto', 'admin-key')
           | first).get('aws_secret_access_key') }}
+
+    - include_tasks: set_aws_sandbox.yaml

--- a/tasks/set_aws_sandbox.yaml
+++ b/tasks/set_aws_sandbox.yaml
@@ -1,0 +1,47 @@
+---
+- debug:
+    msg: >-
+      Sandbox {{ sandbox_name }} picked
+      uuid={{ uuid }}
+      guid={{ guid }}
+      env_type={{ env_type }}"
+
+- name: Save secret of aws_sandbox_secrets dictionary
+  set_fact:
+    aws_sandbox_secrets:
+      sandbox_aws_access_key_id: "{{ sandbox_aws_access_key_id }}"
+      sandbox_aws_secret_access_key: "{{ sandbox_aws_secret_access_key }}"
+      sandbox_hosted_zone_id: "{{ sandbox_hosted_zone_id }}"
+      sandbox_name: "{{ sandbox_name }}"
+      sandbox_account: "{{ sandbox_account }}"
+      sandbox_account_id: "{{ sandbox_account_id }}"
+      sandbox_zone: "{{ sandbox_zone }}"
+      # agnosticd
+      aws_access_key_id: "{{ sandbox_aws_access_key_id }}"
+      aws_secret_access_key: "{{ sandbox_aws_secret_access_key }}"
+      HostedZoneId: "{{ sandbox_hosted_zone_id }}"
+      subdomain_base_suffix: ".{{ sandbox_zone }}"
+
+- name: Inject secrets into dynamic_job_vars
+  set_fact:
+    dynamic_job_vars: >-
+      {{ vars.dynamic_job_vars
+      | default({})
+      | combine(aws_sandbox_secrets, recursive=True) }}
+
+- name: Set sandbox for {{ anarchy_subject_name }}
+  anarchy_subject_update:
+    skip_update_processing: true
+    metadata:
+      labels:
+        sandbox: "{{ sandbox_name }}"
+    spec:
+      vars:
+        job_vars:
+          sandbox_name: "{{ sandbox_name }}"
+          sandbox_account: "{{ sandbox_account }}"
+          sandbox_zone: "{{ sandbox_zone }}"
+          sandbox_hosted_zone_id: "{{ sandbox_hosted_zone_id }}"
+          # agnosticd
+          HostedZoneId: "{{ sandbox_hosted_zone_id }}"
+          subdomain_base_suffix: ".{{ sandbox_zone }}"


### PR DESCRIPTION
see GPTEINFRA-8787

The Anarchy role runs into a problem when it tries to delete Placements that don't have any AWSSandboxes linked to them. This leads to a backlog of failed jobs, as shown by the following error in the ansible log:

```
TASK [babylon_aws_sandbox : Get a placement, book 1 aws sandbox] ***************
FAILED - RETRYING: [localhost]: Get a placement, book 1 aws sandbox (10 retries left).
[...]
FAILED - RETRYING: [localhost]: Get a placement, book 1 aws sandbox (1 retries left).
fatal: [localhost]: FAILED! => {"attempts": 10, "changed": true, "connection": "close", "content_length": "55", "content_type": "application/json", "date": "Wed, 31 Jan 2024 15:22:02 GMT", "elapsed": 0, "json": {"http_code": 409, "message": "Placement already exists"}, "msg": "Status code was 409 and not [200]: HTTP Error 409: Conflict", "redirected": false, "status": 409, "url": "http://....:8080/api/v1/placements"}
```

This change updates the role so it can spot when a placement is empty. When destroying, instead of trying to add a new sandbox, it should remove the empty placement using the Sandbox API.

Also:
- Set aws facts inside downstream tasks
  Simplify the logic, set facts when it's relevant instead of building a long when expression